### PR TITLE
Update control_connection.rb

### DIFF
--- a/lib/cassandra/cluster/control_connection.rb
+++ b/lib/cassandra/cluster/control_connection.rb
@@ -668,6 +668,7 @@ Control connection failed and is unlikely to recover.
       def peer_ip(data)
         ip = data['rpc_address']
         ip = data['peer'] if ip == '0.0.0.0'
+        return nil if ip.nil? == true
 
         @address_resolver.resolve(ip)
       end


### PR DESCRIPTION
After de-comissioning cassandra nodes, system.peers contains entries where rack, host_id, rpc_address, release_version, and tokens columns are null.  We delete them then they come back because of gossip (see Datastax support request #22410).

It appears the code is safe when seeing a nil value returned from peer_ip.

The manifestation of this problem occurs on line lib/cassandra/address_resolution/policies/ec2_multi_region.rb where it attempts to reverse the nil value "ip" as generated by this method